### PR TITLE
Allow installation via go get

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,8 +10,8 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/BurntSushi/toml"
-    "nodebro/page"
-    "nodebro/requests"
+    "github.com/jonaburg/nodebro/page"
+    "github.com/jonaburg/nodebro/requests"
 )
 
 type Config struct {


### PR DESCRIPTION
This resolves the following installation error:
main.go:13:5: package nodebro/page is not in std (/usr/lib/go-1.24/src/nodebro/page)
main.go:14:5: package nodebro/requests is not in std (/usr/lib/go-1.24/src/nodebro/requests)

Sorry that the previous PR wasn't complete.  I thought it was enough but I am new to `go` and `go install`.